### PR TITLE
Update .envrc to support Go 1.16

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,3 @@
 export GOPATH=$PWD
 export PATH=$PWD/bin:$PATH
+export GO111MODULE=off


### PR DESCRIPTION
## Why

Go 1.16 enabled Go Modules by default. More: https://blog.golang.org/go116-module-changes

## What

Disable Go Modules in `.envrc` so that it is still easy to contribute without making too many changes (migrating to Go Modules).
