### PR TITLE
fix: create-env on ubuntu running in windows wsl2 with virtualbox cpi

### DIFF
--- a/src/bosh-virtualbox-cpi/vm/network/add_host_only.go
+++ b/src/bosh-virtualbox-cpi/vm/network/add_host_only.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"bosh-virtualbox-cpi/driver"
 	"fmt"
 	"regexp"
 )
@@ -57,13 +58,17 @@ func (n Networks) configureHostOnly(name, gateway, netmask string) error {
 		args = append(args, "--dhcp")
 	}
 
-	_, err := n.driver.Execute(args...)
+	_, err := n.driver.ExecuteComplex(args, driver.ExecuteOpts{})
 
 	return err
 }
 
 func (n Networks) cleanUpPartialHostOnlyCreate(name string) {
-	_, err := n.driver.Execute("hostonlyif", "remove", name)
+	_, err := n.driver.ExecuteComplex([]string{
+		"hostonlyif",
+		"remove",
+		name,
+	}, driver.ExecuteOpts{})
 	if err != nil {
 		n.logger.Error("vm.network.Networks",
 			"Failed to clean up partially created host-only network '%s': %s", name, err)


### PR DESCRIPTION
If using wsl2 virtualbox cannot be installed on the linux vm itself. It needs to run on the windows host. 
The create env would fail because within the create network shellout The CPI shells out to the VBoxManage Binary to create a network and uses a "name" parameter. On Windows that value would contain " "(spaces), thus the call failed with too many parameters error on the VBoxManage Binary. 

Additionally this requires https://github.com/cloudfoundry/bosh-cli/pull/575 to work since the BOSH CLI hardcoded the PATH to exclude Windows Binary PATH Locations. 

