### PR TITLE
Make agent credentials optional, for accessing blobstore when signed

### DIFF
--- a/jobs/virtualbox_cpi/spec
+++ b/jobs/virtualbox_cpi/spec
@@ -105,9 +105,9 @@ properties:
     description: Port of blobstore server used by simple blobstore plugin
     default: 25250
   blobstore.agent.user:
-    description: Username agent uses to connect to blobstore used by simple blobstore plugin
+    description: Username agent uses to connect to blobstore used by dav blobstore plugin (Optional)
   blobstore.agent.password:
-    description: Password agent uses to connect to blobstore used by simple blobstore plugin
+    description: Password agent uses to connect to blobstore used by dav blobstore plugin (Required only when user is provided
 
   agent.mbus:
     description: Agent mbus

--- a/jobs/virtualbox_cpi/templates/cpi.json.erb
+++ b/jobs/virtualbox_cpi/templates/cpi.json.erb
@@ -18,7 +18,9 @@ params = {
 
 agent_params = params["Agent"]
 
-if_p("blobstore") do
+blobstore_defined = p('blobstore.provider') != 'dav' || !p(['blobstore.agent.user', 'agent.blobstore.address', 'blobstore.address'], nil).nil?
+
+if blobstore_defined do
   agent_params["blobstore"] = {
    "provider" => p("blobstore.provider"),
    "options" => {}
@@ -54,10 +56,12 @@ if_p("blobstore") do
     }
   else
     blobstore["options"] = {
-      "endpoint" => "http://#{p(["agent.blobstore.address", "blobstore.address"])}:#{p("blobstore.port")}",
-      "user" => p("blobstore.agent.user"),
-      "password" => p("blobstore.agent.password")
+      "endpoint" => "http://#{p(['agent.blobstore.address', 'blobstore.address'])}:#{p('blobstore.port')}"
     }
+    if_p('blobstore.agent.user') do
+      blobstore["options"]["user"] = p('blobstore.agent.user')
+      blobstore["options"]["password"] = p('blobstore.agent.password')
+    end
   end
 end
 


### PR DESCRIPTION
When signed URLs are enabled, no agent user/password should be specified in Director's deployment manifest for CPIs config.

Worth to note, since cloudfoundry/bosh-agent@b4ae239 shipped in Agent v2.42.0 on November 2017, the blobstore.options (at the root of the Agent settings JSON) are not used anymore by the Bosh Agent. So nowadays that no more supported Stemcell ships with older Agents, the CPIs should not add those properties anymore to the Agent settings.

related to 
- https://github.com/cloudfoundry/bosh-aws-cpi-release/pull/118
- https://github.com/cloudfoundry/bosh/pull/2327
- https://github.com/cloudfoundry/docs-bosh/pull/755
- https://github.com/cloudfoundry/bosh-davcli/pull/12