### PR TITLE
Support EFI (and other firmware options) support

### DIFF
--- a/docs/cloud-props.md
+++ b/docs/cloud-props.md
@@ -37,6 +37,7 @@ Schema for `cloud_properties` section:
 * **cpus** [Integer, optional]: Number of CPUs. Example: `1`. Default: `1`.
 * **memory** [Integer, optional]: RAM in megabytes. Example: `1024`. Default: `512`.
 * **ephemeral_disk** [Integer, optional]: Ephemeral disk size in megabytes. Example: `10240`. Default: `5000`.
+* **firmware** [String, optional]: Firmware type from bios, efi, efi32, or efi64. Default: 'efi64'  See['Vbox modifyvm general settins](https://www.virtualbox.org/manual/ch08.html#vboxmanage-modifyvm).
 * **paravirtprovider** [String, optional]: Paravirtual provider type. See [`VBoxManage modifyvm` general settings](https://www.virtualbox.org/manual/ch08.html#vboxmanage-modifyvm) for valid values. Default: `default`.
 * **audio** [String, optional]: Audio type. See [`VBoxManage modifyvm` general settings](https://www.virtualbox.org/manual/ch08.html#vboxmanage-modifyvm) for valid values. Default: `none`.
 

--- a/src/bosh-virtualbox-cpi/vm/vm.go
+++ b/src/bosh-virtualbox-cpi/vm/vm.go
@@ -52,6 +52,7 @@ func (vm VMImpl) SetProps(props VMProps) error {
 		"--cpus", strconv.Itoa(props.CPUs),
 		"--paravirtprovider", props.ParavirtProvider,
 		"--audio", props.Audio,
+		"--firmware", props.Firmware,
 	)
 	if err != nil {
 		return err

--- a/src/bosh-virtualbox-cpi/vm/vm_props.go
+++ b/src/bosh-virtualbox-cpi/vm/vm_props.go
@@ -16,6 +16,7 @@ type VMProps struct {
 	EphemeralDisk int    `json:"ephemeral_disk"`
 	Audio         string `json:"audio"`
 
+	Firmware   string `json:"firmware"`
 	GUI              bool
 	ParavirtProvider string `json:"paravirtprovider"`
 
@@ -28,6 +29,7 @@ func NewVMProps(props apiv1.VMCloudProps) (VMProps, error) {
 		CPUs:          1,
 		EphemeralDisk: 5000,
 		Audio:         "none",
+		Firmware:   "efi64",
 
 		ParavirtProvider: "default", // Let vboxmanage decide which paravirtprovider to use
 	}


### PR DESCRIPTION
[PR #348](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/348) added support for EFI in stemcells versions 1.465 and later.  
Virtualbox defaults to BIOS, resulting in unbootable stemcell images.
This change defaults to Virtualbox using EFI64 VMs, and introduces a cloud-config variable to select alternative firmware approaches (or "bios", for compatibility with older stemcells).
No general testing harness seems available; thus testing was done through creating a local CPI release, and going through builds to ascertain that the cloud property propagates through, and yields a working BOSH.