### PR TITLE
fix: Adds LOGNAME/USER environment variables for VirtualBox version 7

### DIFF
--- a/src/bosh-virtualbox-cpi/driver/local_runner.go
+++ b/src/bosh-virtualbox-cpi/driver/local_runner.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"os/user"
 	"strings"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
@@ -38,10 +39,19 @@ func (r LocalRunner) HomeDir() (string, error) {
 func (r LocalRunner) Execute(path string, args ...string) (string, int, error) {
 	r.logger.Debug(r.logTag, "Execute '%s %s'", path, strings.Join(args, "' '"))
 
+	current_user, userErr := user.Current()
+	if userErr != nil {
+		return "", -1, userErr
+	}
+
 	cmd := boshsys.Command{
 		Name: path,
 		Args: args,
-		Env:  map[string]string{"PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"},
+		Env: map[string]string{
+			"PATH":    "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+			"LOGNAME": current_user.Username,
+			"USER":    current_user.Username,
+		},
 	}
 
 	stdout, stderr, status, err := r.cmdRunner.RunComplexCommand(cmd)


### PR DESCRIPTION
Fix for #39 

Removes the _WARNING:_ line that _VBoxManager_ display on any command.

```sh
$ VBoxManage --version
WARNING: Environment variable LOGNAME or USER does not correspond to effective user id.
7.1.4r165100
```

